### PR TITLE
update python-dotenv to 1.0.1

### DIFF
--- a/reqs/app.txt
+++ b/reqs/app.txt
@@ -38,7 +38,7 @@ pygments==2.13.0
     # via rich
 pysocks==1.7.1
     # via urllib3
-python-dotenv==0.20.0
+python-dotenv==1.0.1
     # via webdriver-manager
 requests==2.28.1
     # via


### PR DESCRIPTION
Update python-dotenv dependency to 1.0.1

Our project requires 1.0.1 and we want to use this library. To avoid dependency conflicts, the python-dotenv requirement should be updated.